### PR TITLE
Fix: using current date for CreatedDate if it's not set in the Reserv…

### DIFF
--- a/lib/Application/Schedule/iCalendarReservationView.php
+++ b/lib/Application/Schedule/iCalendarReservationView.php
@@ -40,8 +40,10 @@ class iCalendarReservationView
         $canViewDetails = $privacyFilter->CanViewDetails($currentUser, $res, $res->OwnerId);
 
         $privateNotice = 'Private';
-
-        $this->DateCreated = $res->DateCreated;
+        if ($res->DateCreated){
+                $this->DateCreated = $res->DateCreated;
+        }
+        else $this->DateCreated = Date::Now();
         $this->DateEnd = $res->EndDate;
         $this->DateStart = $res->StartDate;
         $this->Description =  $canViewDetails ? $factory->Format($res, $summaryFormat) : $privateNotice;
@@ -62,7 +64,7 @@ class iCalendarReservationView
 
         $this->StartReminder = $res->StartReminder;
         $this->EndReminder = $res->EndReminder;
-        $this->LastModified = empty($res->ModifiedDate) || $res->ModifiedDate->ToString() == '' ? $res->DateCreated : $res->ModifiedDate;
+        $this->LastModified = empty($res->ModifiedDate) || $res->ModifiedDate->ToString() == '' ? $this->DateCreated : $res->ModifiedDate;
         $this->IsPending = $res->RequiresApproval;
 
         if ($res->OwnerId == $currentUser->UserId) {


### PR DESCRIPTION
…ation Item yet

So that the .ics invites can be valid.
This probably could be fixed somewhere more upstream in the workflow.